### PR TITLE
kubescape: fix duckling-pull secret creation (drop invalid --type flag)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -63,7 +63,7 @@ kubescape:
 	helm repo add kubescape https://raw.githubusercontent.com/k8sstormcenter/helm-charts/gh-pages
 	helm repo update
 	kubectl create ns honey --dry-run=client -o yaml | kubectl apply -f -
-	kubectl create secret docker-registry duckling-pull -n honey --from-file=.dockerconfigjson=$(HOME)/.docker/config.json --type=kubernetes.io/dockerconfigjson --dry-run=client -o yaml | kubectl apply -f -
+	kubectl create secret docker-registry duckling-pull -n honey --from-file=.dockerconfigjson=$(HOME)/.docker/config.json --dry-run=client -o yaml | kubectl apply -f -
 	helm upgrade --install kubescape kubescape/kubescape-operator --version $(KUBESCAPE_CHART_VER) -n honey --create-namespace --values tree/kubescape/values.yaml
 	-kubectl apply  -f tree/kubescape/default-rules.yaml
 	sleep 5

--- a/local-ci.sh
+++ b/local-ci.sh
@@ -102,7 +102,7 @@ kubectl create ns "$KS_NS" --dry-run=client -o yaml | kubectl apply -f -
 # Kubescape
 helm repo add kubescape https://raw.githubusercontent.com/k8sstormcenter/helm-charts/gh-pages 2>/dev/null || true
 helm repo update >/dev/null
-kubectl create secret docker-registry duckling-pull -n "$KS_NS" --from-file=.dockerconfigjson="$HOME/.docker/config.json" --type=kubernetes.io/dockerconfigjson --dry-run=client -o yaml | kubectl apply -f - 2>/dev/null || true
+kubectl create secret docker-registry duckling-pull -n "$KS_NS" --from-file=.dockerconfigjson="$HOME/.docker/config.json" --dry-run=client -o yaml | kubectl apply -f - 2>/dev/null || true
 if ! helm status kubescape -n "$KS_NS" &>/dev/null; then
   helm upgrade --install kubescape kubescape/kubescape-operator --version "$KUBESCAPE_CHART_VER" -n "$KS_NS" --create-namespace --values "$KS_DIR/values.yaml" --set ksNamespace="$KS_NS" --set clusterName=socdemo --set "excludeNamespaces=kube-system\,kube-public\,kube-node-lease\,$CH_NS\,$KS_NS" --wait --timeout 180s 2>/dev/null || echo "  kubescape install may need retry"
 fi

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -84,7 +84,7 @@ deploy:
     hooks:
       before:
         - host:
-            command: ["sh", "-c", "kubectl create ns honey --dry-run=client -o yaml | kubectl apply -f - >/dev/null 2>&1; kubectl create secret docker-registry duckling-pull -n honey --from-file=.dockerconfigjson=$HOME/.docker/config.json --type=kubernetes.io/dockerconfigjson --dry-run=client -o yaml | kubectl apply -f - >/dev/null 2>&1 || true"]
+            command: ["sh", "-c", "kubectl create ns honey --dry-run=client -o yaml | kubectl apply -f - >/dev/null 2>&1; kubectl create secret docker-registry duckling-pull -n honey --from-file=.dockerconfigjson=$HOME/.docker/config.json --dry-run=client -o yaml | kubectl apply -f - >/dev/null 2>&1 || true"]
             os: [linux, darwin]
       # node-agent loads rules at boot; on redeploy (or if it started before the
       # rawYaml rules landed) bounce it so R0002-on/R0003-off/R0011-on take effect.


### PR DESCRIPTION
Follow-up to #253. `kubectl create secret docker-registry` does not accept `--type`; the docker-registry subcommand already sets `kubernetes.io/dockerconfigjson`. As merged, `make kubescape` / local-ci / the skaffold before-hook error on that line. Removes the flag in Makefile, local-ci.sh, and skaffold.yaml.