### PR TITLE
clickhouse: create kubescape governance tables at deploy (+ ks-sync individual profile read)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -63,7 +63,7 @@ kubescape:
 	helm repo add kubescape https://raw.githubusercontent.com/k8sstormcenter/helm-charts/gh-pages
 	helm repo update
 	kubectl create ns honey --dry-run=client -o yaml | kubectl apply -f -
-	kubectl create secret docker-registry duckling-pull -n honey --from-file=.dockerconfigjson=$(HOME)/.docker/config.json --type=kubernetes.io/dockerconfigjson --dry-run=client -o yaml | kubectl apply -f -
+	kubectl create secret docker-registry duckling-pull -n honey --from-file=.dockerconfigjson=$(HOME)/.docker/config.json --dry-run=client -o yaml | kubectl apply -f -
 	helm upgrade --install kubescape kubescape/kubescape-operator --version $(KUBESCAPE_CHART_VER) -n honey --create-namespace --values tree/kubescape/values.yaml
 	-kubectl apply  -f tree/kubescape/default-rules.yaml
 	sleep 5

--- a/local-ci.sh
+++ b/local-ci.sh
@@ -102,7 +102,7 @@ kubectl create ns "$KS_NS" --dry-run=client -o yaml | kubectl apply -f -
 # Kubescape
 helm repo add kubescape https://raw.githubusercontent.com/k8sstormcenter/helm-charts/gh-pages 2>/dev/null || true
 helm repo update >/dev/null
-kubectl create secret docker-registry duckling-pull -n "$KS_NS" --from-file=.dockerconfigjson="$HOME/.docker/config.json" --type=kubernetes.io/dockerconfigjson --dry-run=client -o yaml | kubectl apply -f - 2>/dev/null || true
+kubectl create secret docker-registry duckling-pull -n "$KS_NS" --from-file=.dockerconfigjson="$HOME/.docker/config.json" --dry-run=client -o yaml | kubectl apply -f - 2>/dev/null || true
 if ! helm status kubescape -n "$KS_NS" &>/dev/null; then
   helm upgrade --install kubescape kubescape/kubescape-operator --version "$KUBESCAPE_CHART_VER" -n "$KS_NS" --create-namespace --values "$KS_DIR/values.yaml" --set ksNamespace="$KS_NS" --set clusterName=socdemo --set "excludeNamespaces=kube-system\,kube-public\,kube-node-lease\,$CH_NS\,$KS_NS" --wait --timeout 180s 2>/dev/null || echo "  kubescape install may need retry"
 fi

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -113,6 +113,7 @@ manifests:
   rawYaml:
     # node-local delivery to dx (#228) — replaces the fragile ${HOST_IP} sink.
     - tree/vector-lab/dx-daemon-service.yaml
+    - tree/ks-sync/ks-sync.yaml
 deploy:
   helm: {}
   kubectl:

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -84,7 +84,7 @@ deploy:
     hooks:
       before:
         - host:
-            command: ["sh", "-c", "kubectl create ns honey --dry-run=client -o yaml | kubectl apply -f - >/dev/null 2>&1; kubectl create secret docker-registry duckling-pull -n honey --from-file=.dockerconfigjson=$HOME/.docker/config.json --type=kubernetes.io/dockerconfigjson --dry-run=client -o yaml | kubectl apply -f - >/dev/null 2>&1 || true"]
+            command: ["sh", "-c", "kubectl create ns honey --dry-run=client -o yaml | kubectl apply -f - >/dev/null 2>&1; kubectl create secret docker-registry duckling-pull -n honey --from-file=.dockerconfigjson=$HOME/.docker/config.json --dry-run=client -o yaml | kubectl apply -f - >/dev/null 2>&1 || true"]
             os: [linux, darwin]
       # node-agent loads rules at boot; on redeploy (or if it started before the
       # rawYaml rules landed) bounce it so R0002-on/R0003-off/R0011-on take effect.

--- a/tree/clickhouse-lab/schema.sql
+++ b/tree/clickhouse-lab/schema.sql
@@ -82,3 +82,52 @@ CREATE TABLE IF NOT EXISTS forensic_db.kubescape_logs (
   PARTITION BY toYYYYMM(fromUnixTimestamp64Nano(event_time))
   TTL toDateTime(fromUnixTimestamp64Nano(event_time)) + INTERVAL 30 DAY DELETE
   SETTINGS index_granularity = 8192;
+
+-- Governance tables. ks-sync (tree/ks-sync) also creates these IF NOT EXISTS on
+-- its first CronJob run, but the dx views (dx/shadow_profiles, dx/profile_coverage,
+-- dx/signatures) read them DIRECTLY and fail to compile on a fresh cluster until
+-- the table exists. Create them at deploy so the views resolve before ks-sync fires
+-- (and so a demo-dump restore can INSERT without pre-existing schema). DDL is kept
+-- byte-identical to ks-sync.yaml — divergence breaks its inserts.
+CREATE TABLE IF NOT EXISTS forensic_db.kubescape_profiles (
+    event_time      UInt64,
+    hostname        String,
+    ts              DateTime,
+    namespace       String,
+    name            String,
+    kind            String,
+    managed_by      String,
+    completion      String,
+    status          String,
+    signed          Int64,
+    signer_identity String,
+    signer_issuer   String,
+    execs           UInt32,
+    opens           UInt32,
+    egress          UInt32,
+    ingress         UInt32,
+    syscalls        UInt32,
+    capabilities    String
+) ENGINE = MergeTree ORDER BY (event_time, namespace, name);
+
+CREATE TABLE IF NOT EXISTS forensic_db.kubescape_rogueartifacts (
+    event_time     UInt64,
+    hostname       String,
+    ts             DateTime,
+    namespace      String,
+    name           String,
+    container_name String,
+    workload_name  String,
+    workload_kind  String,
+    pod_name       String,
+    rogue_phase    String
+) ENGINE = MergeTree ORDER BY (event_time, namespace, name);
+
+CREATE TABLE IF NOT EXISTS forensic_db.kubescape_trust (
+    event_time    UInt64,
+    hostname      String,
+    ts            DateTime,
+    class         String,
+    signer_key    String,
+    allowed_paths String
+) ENGINE = MergeTree ORDER BY (event_time, class, signer_key);

--- a/tree/ks-sync/ks-sync.yaml
+++ b/tree/ks-sync/ks-sync.yaml
@@ -49,7 +49,7 @@ data:
     CH = os.environ.get("CH_ENDPOINT", "http://clickhouse-forensic-soc-db.clickhouse.svc.cluster.local:8123")
     AUTH = "Basic " + base64.b64encode(
         (os.environ.get("CH_USER", "ingest_writer") + ":" + os.environ.get("CH_PASS", "changeme-ingest")).encode()).decode()
-    HOST = os.environ.get("SHARD_HOST", "node-01")
+    HOST = os.environ.get("SHARD_HOST") or os.environ["NODE_NAME"]
     STAMP = {"event_time": int(time.time() * 1e9), "hostname": HOST,
              "ts": datetime.datetime.now().strftime("%Y-%m-%d %H:%M:%S")}
     GRP = "/apis/spdx.softwarecomposition.kubescape.io/v1beta1"
@@ -136,6 +136,16 @@ spec:
             - name: sync
               image: python:3.11-slim
               command: ["python3", "/scripts/sync.py"]
+              env:
+                # Shard host MUST be a node where a vizier PEM runs: the PEM injects
+                # `WHERE hostname = gethostname()` (its own node — it is hostNetwork)
+                # on every clickhouse_dsn read, so rows stamped with any other value
+                # return 0. A CronJob has no control-plane toleration, so it lands on
+                # a worker, which always has a PEM — its own node is a valid shard host.
+                - name: NODE_NAME
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: spec.nodeName
               volumeMounts:
                 - name: script
                   mountPath: /scripts

--- a/tree/ks-sync/ks-sync.yaml
+++ b/tree/ks-sync/ks-sync.yaml
@@ -1,0 +1,141 @@
+# Kubescape state -> ClickHouse sync. Every 2 min, reads ContainerProfiles,
+# RogueArtifacts and the node-agent trust-policy from the k8s API and writes
+# them (timestamped snapshots) into forensic_db so the dx/* governance views can
+# display them. Stdlib python only (no kubectl/pip). Self-creates the tables.
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: ks-ch-sync
+  namespace: honey
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: ks-ch-sync
+rules:
+  - apiGroups: ["spdx.softwarecomposition.kubescape.io"]
+    resources: ["containerprofiles", "rogueartifacts"]
+    verbs: ["get", "list"]
+  - apiGroups: [""]
+    resources: ["configmaps"]
+    verbs: ["get"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: ks-ch-sync
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: ks-ch-sync
+subjects:
+  - kind: ServiceAccount
+    name: ks-ch-sync
+    namespace: honey
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: ks-ch-sync
+  namespace: honey
+data:
+  sync.py: |
+    import json, os, ssl, time, datetime, base64, urllib.request, urllib.parse
+
+    K8S = "https://kubernetes.default.svc"
+    SA = "/var/run/secrets/kubernetes.io/serviceaccount"
+    TOKEN = open(SA + "/token").read().strip()
+    CTX = ssl.create_default_context(cafile=SA + "/ca.crt")
+    CH = os.environ.get("CH_ENDPOINT", "http://clickhouse-forensic-soc-db.clickhouse.svc.cluster.local:8123")
+    AUTH = "Basic " + base64.b64encode(
+        (os.environ.get("CH_USER", "ingest_writer") + ":" + os.environ.get("CH_PASS", "changeme-ingest")).encode()).decode()
+    HOST = os.environ.get("SHARD_HOST", "node-01")
+    STAMP = {"event_time": int(time.time() * 1e9), "hostname": HOST,
+             "ts": datetime.datetime.now().strftime("%Y-%m-%d %H:%M:%S")}
+    GRP = "/apis/spdx.softwarecomposition.kubescape.io/v1beta1"
+
+    def kget(path):
+        req = urllib.request.Request(K8S + path, headers={"Authorization": "Bearer " + TOKEN})
+        return json.loads(urllib.request.urlopen(req, context=CTX, timeout=30).read())
+
+    def ch(query, data=b""):
+        req = urllib.request.Request(CH + "/?query=" + urllib.parse.quote(query), data=data,
+                                     headers={"Authorization": AUTH})
+        return urllib.request.urlopen(req, timeout=30).read()
+
+    def insert(table, rows):
+        for r in rows:
+            r.update(STAMP)
+        if rows:
+            ch("INSERT INTO forensic_db." + table + " FORMAT JSONEachRow",
+               "\n".join(json.dumps(r) for r in rows).encode())
+        print("  %s: %d" % (table, len(rows)))
+
+    ch("CREATE TABLE IF NOT EXISTS forensic_db.kubescape_profiles (event_time UInt64, hostname String, ts DateTime, namespace String, name String, kind String, managed_by String, completion String, status String, signed Int64, signer_identity String, signer_issuer String, execs UInt32, opens UInt32, egress UInt32, ingress UInt32, syscalls UInt32, capabilities String) ENGINE=MergeTree ORDER BY (event_time, namespace, name)")
+    ch("CREATE TABLE IF NOT EXISTS forensic_db.kubescape_rogueartifacts (event_time UInt64, hostname String, ts DateTime, namespace String, name String, container_name String, workload_name String, workload_kind String, pod_name String, rogue_phase String) ENGINE=MergeTree ORDER BY (event_time, namespace, name)")
+    ch("CREATE TABLE IF NOT EXISTS forensic_db.kubescape_trust (event_time UInt64, hostname String, ts DateTime, class String, signer_key String, allowed_paths String) ENGINE=MergeTree ORDER BY (event_time, class, signer_key)")
+
+    prows = []
+    for it in kget(GRP + "/containerprofiles").get("items", []):
+        m = it["metadata"]; a = m.get("annotations", {}) or {}; l = m.get("labels", {}) or {}; s = it.get("spec", {}) or {}
+        mb = l.get("kubescape.io/managed-by", "")
+        prows.append({"namespace": m.get("namespace", ""), "name": m.get("name", ""),
+                      "kind": "user" if mb == "user" else "shadow", "managed_by": mb,
+                      "completion": a.get("kubescape.io/completion", ""), "status": a.get("kubescape.io/status", ""),
+                      "signed": 1 if a.get("signature.kubescape.io/signature") else 0,
+                      "signer_identity": a.get("signature.kubescape.io/identity", ""),
+                      "signer_issuer": a.get("signature.kubescape.io/issuer", ""),
+                      "execs": len(s.get("execs") or []), "opens": len(s.get("opens") or []),
+                      "egress": len(s.get("egress") or []), "ingress": len(s.get("ingress") or []),
+                      "syscalls": len(s.get("syscalls") or []), "capabilities": ",".join(s.get("capabilities") or [])})
+    insert("kubescape_profiles", prows)
+
+    rrows = []
+    for it in kget(GRP + "/rogueartifacts").get("items", []):
+        m = it["metadata"]; l = m.get("labels", {}) or {}; s = it.get("spec", {}) or {}
+        rrows.append({"namespace": m.get("namespace", ""), "name": m.get("name", ""),
+                      "container_name": l.get("kubescape.io/container-name", ""),
+                      "workload_name": s.get("workloadName", ""), "workload_kind": s.get("workloadKind", ""),
+                      "pod_name": s.get("podName", ""),
+                      "rogue_phase": l.get("kubescape.io/rogue-phase", "") or s.get("state", "")})
+    insert("kubescape_rogueartifacts", rrows)
+
+    trows = []
+    try:
+        cm = kget("/api/v1/namespaces/honey/configmaps/node-agent-bundle-policy")
+        doc = json.loads(cm["data"]["trust-policy.json"])
+        for cls, cfg in (doc.get("policy") or doc).get("classes", {}).items():
+            for sk in cfg.get("signers", []):
+                trows.append({"class": cls, "signer_key": sk, "allowed_paths": ",".join(cfg.get("allowedSpecPaths", []))})
+    except Exception as e:
+        print("  trust:", e)
+    insert("kubescape_trust", trows)
+---
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: ks-ch-sync
+  namespace: honey
+spec:
+  schedule: "*/2 * * * *"
+  concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: 1
+  failedJobsHistoryLimit: 2
+  jobTemplate:
+    spec:
+      backoffLimit: 1
+      template:
+        spec:
+          serviceAccountName: ks-ch-sync
+          restartPolicy: Never
+          containers:
+            - name: sync
+              image: python:3.11-slim
+              command: ["python3", "/scripts/sync.py"]
+              volumeMounts:
+                - name: script
+                  mountPath: /scripts
+          volumes:
+            - name: script
+              configMap:
+                name: ks-ch-sync

--- a/tree/ks-sync/ks-sync.yaml
+++ b/tree/ks-sync/ks-sync.yaml
@@ -76,8 +76,12 @@ data:
     ch("CREATE TABLE IF NOT EXISTS forensic_db.kubescape_trust (event_time UInt64, hostname String, ts DateTime, class String, signer_key String, allowed_paths String) ENGINE=MergeTree ORDER BY (event_time, class, signer_key)")
 
     prows = []
-    for it in kget(GRP + "/containerprofiles").get("items", []):
-        m = it["metadata"]; a = m.get("annotations", {}) or {}; l = m.get("labels", {}) or {}; s = it.get("spec", {}) or {}
+    # LIST truncates ContainerProfile.spec (execs/opens/egress come back empty);
+    # GET each profile individually for the real behaviour set.
+    for lit in kget(GRP + "/containerprofiles").get("items", []):
+        ns = lit["metadata"].get("namespace", ""); nm = lit["metadata"].get("name", "")
+        it = kget(GRP + "/namespaces/" + ns + "/containerprofiles/" + nm)
+        m = it.get("metadata", {}); a = m.get("annotations", {}) or {}; l = m.get("labels", {}) or {}; s = it.get("spec", {}) or {}
         mb = l.get("kubescape.io/managed-by", "")
         prows.append({"namespace": m.get("namespace", ""), "name": m.get("name", ""),
                       "kind": "user" if mb == "user" else "shadow", "managed_by": mb,

--- a/tree/kubescape/values.yaml
+++ b/tree/kubescape/values.yaml
@@ -14,7 +14,7 @@ nodeAgent:
   config:
     alertManagerExporterUrls:
       - alertmanager.honey.svc.cluster.local:9093
-    maxLearningPeriod: 2m
+    maxLearningPeriod: 24h
     learningPeriod: 2m
     updatePeriod: 10000m
     networkServiceResolution: true

--- a/tree/kubescape/values.yaml
+++ b/tree/kubescape/values.yaml
@@ -15,7 +15,7 @@ nodeAgent:
     alertManagerExporterUrls:
       - alertmanager.honey.svc.cluster.local:9093
     maxLearningPeriod: 24h
-    learningPeriod: 2m
+    learningPeriod: 10m
     updatePeriod: 10000m
     networkServiceResolution: true
     ruleCooldown:


### PR DESCRIPTION
## Why
On a **fresh cluster**, `dx/shadow_profiles`, `dx/profile_coverage`, and `dx/signatures` fail to compile:

```
Table 'kubescape_profiles' not found in relation_map and failed to infer from ClickHouse:
Table forensic_db.kubescape_profiles does not exist.
```

These views read `forensic_db.kubescape_profiles` / `kubescape_rogueartifacts` / `kubescape_trust` **directly**. AE/dx create the `dx_*` tables and vector creates `kubescape_logs`, but nothing creates the three governance tables at deploy — only `ks-sync`'s CronJob does, whenever it first fires. Until then the views don't compile, and a demo-dump restore has no table to `INSERT` into.

## What
- **`clickhouse-lab/schema.sql`**: create the 3 governance tables at deploy (`CREATE TABLE IF NOT EXISTS`, DDL byte-identical to `ks-sync.yaml` — no conflict with ks-sync's own creation).
- **`ks-sync.yaml`**: GET each `ContainerProfile` individually — the LIST endpoint truncates `.spec`, so `execs/opens/egress/ingress` were coming back `0`.

Also carries the ks-sync CronJob + `maxLearningPeriod=24h` / `learningPeriod=10m` wiring already staged on this line.

## Result
Views resolve on a clean cluster before ks-sync fires; demo-dump restores land cleanly.