### PR TITLE
howtoinstallstack: pem-direct is the default (node-local real-time)

### DIFF
--- a/howtoinstallstack.md
+++ b/howtoinstallstack.md
@@ -55,17 +55,23 @@ skaffold deploy -f skaffold/skaffold_dx.yaml                 # DX 0.5.0-keepset-
   missing so `apply.go` recreates them).
 - DX creates the `dx_orders` / `dx_ord__*` / `dx_src__kubescape_mitre` schema the
   `dx/*` views read.
-- **DX reads its evidence via the in-cluster query-broker — `DX_BENCH=broker`** (wired
-  in `skaffold_dx.yaml`; the skaffold sets up everything the broker path needs). This is
-  the reliable in-cluster path — **do not switch it to `pemdirect`.** `pemdirect` dials a
-  PEM direct-query listener that the stock PEM (0.14.17) does not ship, so it is refused
-  and dx goes **blind**: every dx-owned table (`conn_stats`, `dc_snoop`, `stack_trace`,
-  `redis_events`, `mysql_events`, …) renders empty while the AE-owned tables
-  (`http_events`, `dns_events`, `pgsql_events`, `creds_change`) stay populated. Confirm
-  the right path with the dx-daemon log line
-  `bench=broker (pxapi → in-cluster vizier-query-broker …)` — if you instead see
-  `bench=px` (px CLI) or `bench UNAVAILABLE`, the broker path didn't select and the
-  dx-owned panels will be blank.
+- **PEM, AE, and DX all query node-local via pem-direct — that is real-time
+  detection.** Each PEM answers queries from its OWN node on `:50305`; no cloud or
+  broker round-trip. This needs **our** PEM line, not stock Pixie: stock `0.14.17`
+  does not ship the `:50305` direct-query listener, so pem-direct is refused and dx
+  goes **blind** (every dx-owned table — `conn_stats`, `dc_snoop`, `stack_trace`,
+  `redis_events`, `mysql_events`, … — renders empty). Our PEM ships it (pem-direct
+  is default-on in `main` since #87) and is built alongside AE at the same tag.
+  - **PEM image: `ghcr.io/k8sstormcenter/vizier-pem_image:0.14.19-aeprod90`** —
+    pinned in the pixie `k8s/vizier/pem` overlay, so it deploys with the vizier
+    skaffold in §3 (no extra step).
+  - AE queries its own node: `ADAPTIVE_VIZIER_DIRECT_ADDR=$(HOST_IP):50305`
+    (already set in `adaptive_export_deployment.yaml`).
+  - DX queries its own node: `DX_BENCH=pemdirect`. Confirm with the dx-daemon log
+    line `bench=pemdirect (… :50305)`. If you see `bench=broker`,
+    `bench=px`, or `bench UNAVAILABLE`, pem-direct didn't select — the usual cause
+    is a stock `0.14.17` PEM instead of our line; verify with
+    `kubectl -n pl get ds vizier-pem -o jsonpath='{..image}'`.
 - **dx is order-driven — its tables stay empty until an alert fires.** Right after
   deploy, `conn_stats` / `dc_snoop` / `stack_trace` / the protocol tables read **0**
   because no anomaly has produced a referral yet. This is expected — do **not** read it


### PR DESCRIPTION
## What

Flip the stack's PEM guidance from **broker workaround** back to the target:
**pem-direct** (node-local `:50305`). Real-time detection queries each PEM on its
OWN node — no cloud/broker round-trip.

- §2: `DX_BENCH=broker` → `DX_BENCH=pemdirect`; pin the PEM image to our line.
- **PEM: `ghcr.io/k8sstormcenter/vizier-pem_image:0.14.19-aeprod90`** — pinned in
  pixie `k8s/vizier/pem` overlay (pixie `feat/pixie-native-sbob` @ `2a36ff38b`),
  deploys with the vizier skaffold, no extra step.
- AE unchanged — already `ADAPTIVE_VIZIER_DIRECT_ADDR=$(HOST_IP):50305`; it only
  failed because the *stock* `0.14.17` pem never binds `:50305`.

## Why now

`pem-direct` is default-on in pixie `main` since #87 (2026-07-20). Every pem built
from main since — incl. `aeprod90`, built alongside AE — ships the `:50305`
listener. The "do not use pemdirect" note was a stock-pem-era workaround; with our
line pinned it's obsolete. Broker means a round-trip, which defeats node-local
real-time.

## DRAFT — gates before ready

- [ ] build-agent / dx-97 confirm `vizier-pem_image:0.14.19-aeprod90` is pullable
      with pem-direct compiled (pixie#92).
- [ ] PG validation: our pem + AE `:50305` + dx `DX_BENCH=pemdirect`, ingress-
      nightmare fires, dx-owned panels populate, `bench=pemdirect` in dx log.
- [ ] edge4 validation (same).
- [ ] dx side: `DX_BENCH=pemdirect` wired in the dx deploy (dx-97 / entlein/dx#146).