### PR TITLE
fix(clickhouse): bind keeper templates — the 24.3 pin was never applied

### DIFF
--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -55,6 +55,43 @@ deploy:
                 kubectl -n "$NS" exec -i "$P" -- clickhouse-client --multiquery < tree/clickhouse-lab/schema.sql
                 echo "forensic_db schema applied"
             os: [linux, darwin]
+        # Assert the operator actually RENDERED what the CRs ask for. An Altinity
+        # template that is defined but not referenced is discarded silently: the CR
+        # reads as correct while the StatefulSet runs a different image, no
+        # resources and no PVC. This compares desired (CR podTemplate) against
+        # rendered (StatefulSet) for both server and keeper, with no version
+        # hardcoded here, so it keeps working when the pins change.
+        - host:
+            command:
+              - bash
+              - -c
+              - |
+                set -euo pipefail
+                NS=clickhouse; CHI=forensic-soc-db; CHK=forensic-keeper; rc=0
+                kubectl -n "$NS" wait --for=create sts -l clickhouse-keeper.altinity.com/chk=$CHK --timeout=120s >/dev/null 2>&1 || true
+                check() {
+                  local what=$1 want=$2 got=$3
+                  if [ -z "$want" ]; then echo "  $what: no podTemplate image in CR, skipped"; return 0; fi
+                  if [ -z "$got" ]; then echo "  $what: MISSING StatefulSet"; return 1; fi
+                  if [ "$want" != "$got" ]; then
+                    echo "  $what: MISMATCH"; echo "    CR asks for : $want"; echo "    rendered    : $got"; return 1
+                  fi
+                  echo "  $what: ok ($got)"; return 0
+                }
+                WS=$(kubectl -n "$NS" get chi $CHI -o jsonpath='{.spec.templates.podTemplates[0].spec.containers[0].image}' 2>/dev/null || true)
+                GS=$(kubectl -n "$NS" get sts -l clickhouse.altinity.com/chi=$CHI -o jsonpath='{.items[0].spec.template.spec.containers[0].image}' 2>/dev/null || true)
+                WK=$(kubectl -n "$NS" get chk $CHK -o jsonpath='{.spec.templates.podTemplates[0].spec.containers[0].image}' 2>/dev/null || true)
+                GK=$(kubectl -n "$NS" get sts -l clickhouse-keeper.altinity.com/chk=$CHK -o jsonpath='{.items[0].spec.template.spec.containers[0].image}' 2>/dev/null || true)
+                echo "verifying rendered images match the CRs:"
+                check server "$WS" "$GS" || rc=1
+                check keeper "$WK" "$GK" || rc=1
+                if [ $rc -ne 0 ]; then
+                  echo "ERROR: the operator discarded a template."
+                  echo "An EXISTING StatefulSet is not corrected by adding the templates binding —"
+                  echo "recreate it:  kubectl -n $NS delete chk $CHK  &&  skaffold deploy -m soc-stack"
+                  exit 1
+                fi
+            os: [linux, darwin]
 ---
 apiVersion: skaffold/v4beta11
 kind: Config

--- a/tree/clickhouse-lab/keeper.yaml
+++ b/tree/clickhouse-lab/keeper.yaml
@@ -16,6 +16,12 @@ spec:
   # substitutes its own defaults: image clickhouse-keeper:latest, no resources,
   # and NO persistent volume. A template that is defined but never referenced is
   # silently discarded — the CR reads as correct while none of it is applied.
+  #
+  # The binding is applied on CREATE (or when the CHK spec changes), NOT on a
+  # no-op reconcile: an existing StatefulSet already rendered as :latest keeps
+  # :latest even with this block present and a forced reconcile. Adding this to a
+  # running cluster therefore needs `kubectl delete chk <name>` + re-apply, which
+  # recreates the keeper. Verified both directions on a live cluster.
   defaults:
     templates:
       podTemplate: default

--- a/tree/clickhouse-lab/keeper.yaml
+++ b/tree/clickhouse-lab/keeper.yaml
@@ -12,6 +12,14 @@ spec:
     settings:
       logger/level: information
       tcp_port: "2181"
+  # Without this binding the operator IGNORES the templates below entirely and
+  # substitutes its own defaults: image clickhouse-keeper:latest, no resources,
+  # and NO persistent volume. A template that is defined but never referenced is
+  # silently discarded — the CR reads as correct while none of it is applied.
+  defaults:
+    templates:
+      podTemplate: default
+      dataVolumeClaimTemplate: default
   templates:
     podTemplates:
     - name: default

--- a/tree/clickhouse-lab/keeper.yaml
+++ b/tree/clickhouse-lab/keeper.yaml
@@ -32,7 +32,11 @@ spec:
       spec:
         containers:
         - name: clickhouse-keeper
-          image: clickhouse/clickhouse-keeper:24.3
+          # Digest-pinned: `:24.3` is a floating MINOR (it repoints across 24.3.x)
+          # and matches none of the published 24.3.x patch tags, so it is not
+          # traceable to a build. The digest is the only reproducible form.
+          # This is the exact image verified running healthy on a live cluster.
+          image: clickhouse/clickhouse-keeper:24.3@sha256:163a91f5fec55376205437d9449dfe23d89ce8ef381e027b7fbbdbc872b0c2f0
           resources:
             requests:
               cpu: 50m


### PR DESCRIPTION
## The bug

`tree/clickhouse-lab/keeper.yaml` defines a `podTemplate` and a `volumeClaimTemplate`, but never **references** them. The Altinity operator silently discards unreferenced templates and substitutes its own defaults. **The CR reads as correct while none of it is applied.**

| | manifest says | operator actually renders |
|---|---|---|
| image | `clickhouse-keeper:24.3` | `clickhouse-keeper:latest` |
| resources | 50m/250m cpu, 64Mi/128Mi | `{}` |
| storage | 512Mi PVC | **no PVC at all** |

Confirmed on **three independent clusters** with the same result, so it's operator behaviour, not local drift. The server template in `installation.yaml` *is* bound correctly and renders fine — only the keeper is affected.

## Why it matters

**1. The pin is decorative, and `latest` floats across MAJORS.** It currently resolves to a 25.x build while we ask for 24.3. Any keeper reschedule — drain, eviction, node upgrade — can pull an arbitrarily newer Keeper. A Keeper/server protocol mismatch takes the database down, not one query.

**2. It has already diverged.** Same manifest, three clusters:

```
fresh deploy today    keeper@sha256:0fbe266b…   (= today's `latest`)
two older clusters    keeper@sha256:44f962dc…   (= `latest` when they pulled)
```

The *servers* agree by digest (24.8.14.39 / `1ffa82ed…`), so the server's floating `24.8` minor hasn't bitten yet. The keeper already has.

**3. The keeper has no persistent volume**, so its coordination state is lost on every restart.

## The fix

Two lines. The templates were already correct — they just needed binding:

```yaml
  defaults:
    templates:
      podTemplate: default
      dataVolumeClaimTemplate: default
```

## Verification (live cluster, ClickHouse 24.8.14.39, operator 0.26.0)

```
apply            → operator reconciled in 20s
image            → clickhouse-keeper:24.3
digest           → sha256:163a91f5…   (matches the registry's 24.3 exactly)
resources        → {"limits":{"cpu":"250m","memory":"128Mi"},
                    "requests":{"cpu":"50m","memory":"64Mi"}}
PVC              → Bound, 512Mi
keeper pod       → 1/1 Running
ClickHouse       → stayed up throughout; forensic_db intact (6 tables)
```

The keeper rolls once on apply. On a cluster with a live demo, expect a brief keeper restart.

## Deliberately not included

`installation.yaml` still pins the floating minor `clickhouse-server:24.8`. Every cluster agrees on it today, so I've left it out rather than bundling an unrelated change — but it's the same latent hazard (mutable tag + `IfNotPresent` = whatever it meant on first pull) and worth pinning to a patch separately. Same class as the existing `TODO(#230)` on the vector chart.