### PR TITLE
chore(kubescape): chart 1.41.0-duckling6, node-agent v0.1.0-rogue8

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 NAME ?= sovereignsoc
 CLUSTER_NAME := $(NAME)
 HELM := $(shell which helm)
-KUBESCAPE_CHART_VER ?= 1.41.0-duckling3
+KUBESCAPE_CHART_VER ?= 1.41.0-duckling4
 
 CURRENT_CONTEXT := $(shell kubectl config current-context)
 OS := $(shell uname -s | tr '[:upper:]' '[:lower:]')

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 NAME ?= sovereignsoc
 CLUSTER_NAME := $(NAME)
 HELM := $(shell which helm)
-KUBESCAPE_CHART_VER ?= 1.41.0-duckling4
+KUBESCAPE_CHART_VER ?= 1.41.0-duckling5
 
 CURRENT_CONTEXT := $(shell kubectl config current-context)
 OS := $(shell uname -s | tr '[:upper:]' '[:lower:]')

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 NAME ?= sovereignsoc
 CLUSTER_NAME := $(NAME)
 HELM := $(shell which helm)
-KUBESCAPE_CHART_VER ?= 1.41.0-duckling5
+KUBESCAPE_CHART_VER ?= 1.41.0-duckling6
 
 CURRENT_CONTEXT := $(shell kubectl config current-context)
 OS := $(shell uname -s | tr '[:upper:]' '[:lower:]')

--- a/howtoinstallstack.md
+++ b/howtoinstallstack.md
@@ -31,7 +31,7 @@ This brings up, in order (the module chains the dependencies):
 
 - **ClickHouse** `forensic-soc-db` with the `forensic_db` schema.
 - **Kubescape operator**, chart
-  `kubescape-operator-1.41.0-duckling5` (from the k8sstormcenter helm-charts release),
+  `kubescape-operator-1.41.0-duckling6` (from the k8sstormcenter helm-charts release),
   node-agent `docker.io/entlein/duckling:v0.1.0-rogue8`, storage `rc-rogue5`,
   `maxLearningPeriod: 24h`, `learningPeriod: 10m`.
 - **Vector** (kubescape → ClickHouse pipeline) + the **dx-wiring**.

--- a/howtoinstallstack.md
+++ b/howtoinstallstack.md
@@ -31,8 +31,8 @@ This brings up, in order (the module chains the dependencies):
 
 - **ClickHouse** `forensic-soc-db` with the `forensic_db` schema.
 - **Kubescape operator**, chart
-  `kubescape-operator-1.41.0-duckling4` (from the k8sstormcenter helm-charts release),
-  node-agent `docker.io/entlein/duckling:v0.1.0-rogue7`, storage `rc-rogue5`,
+  `kubescape-operator-1.41.0-duckling5` (from the k8sstormcenter helm-charts release),
+  node-agent `docker.io/entlein/duckling:v0.1.0-rogue8`, storage `rc-rogue5`,
   `maxLearningPeriod: 24h`, `learningPeriod: 10m`.
 - **Vector** (kubescape → ClickHouse pipeline) + the **dx-wiring**.
 - The **`ks-ch-sync`** CronJob (kubescape ContainerProfiles / rogue artifacts / trust

--- a/howtoinstallstack.md
+++ b/howtoinstallstack.md
@@ -31,8 +31,8 @@ This brings up, in order (the module chains the dependencies):
 
 - **ClickHouse** `forensic-soc-db` with the `forensic_db` schema.
 - **Kubescape operator**, chart
-  `kubescape-operator-1.41.0-duckling2` (from the k8sstormcenter helm-charts release),
-  node-agent `docker.io/entlein/duckling:v0.1.0-rogue2`, storage `rc-rogue5`,
+  `kubescape-operator-1.41.0-duckling4` (from the k8sstormcenter helm-charts release),
+  node-agent `docker.io/entlein/duckling:v0.1.0-rogue7`, storage `rc-rogue5`,
   `maxLearningPeriod: 24h`, `learningPeriod: 10m`.
 - **Vector** (kubescape → ClickHouse pipeline) + the **dx-wiring**.
 - The **`ks-ch-sync`** CronJob (kubescape ContainerProfiles / rogue artifacts / trust

--- a/local-ci.sh
+++ b/local-ci.sh
@@ -13,7 +13,7 @@ CH_NS="socdemo-ch"
 KS_NS="socdemo"
 CHI="forensic-soc-db"
 INFER_JSON="$CH_DIR/infer_flat.json"
-KUBESCAPE_CHART_VER="${KUBESCAPE_CHART_VER:-1.41.0-duckling5}"
+KUBESCAPE_CHART_VER="${KUBESCAPE_CHART_VER:-1.41.0-duckling6}"
 
 PASS=0; FAIL=0
 check() { if eval "$2" >/dev/null 2>&1; then echo "  PASS: $1"; PASS=$((PASS+1)); else echo "  FAIL: $1"; FAIL=$((FAIL+1)); fi; return 0; }

--- a/local-ci.sh
+++ b/local-ci.sh
@@ -13,7 +13,7 @@ CH_NS="socdemo-ch"
 KS_NS="socdemo"
 CHI="forensic-soc-db"
 INFER_JSON="$CH_DIR/infer_flat.json"
-KUBESCAPE_CHART_VER="${KUBESCAPE_CHART_VER:-1.41.0-duckling2}"
+KUBESCAPE_CHART_VER="${KUBESCAPE_CHART_VER:-1.41.0-duckling4}"
 
 PASS=0; FAIL=0
 check() { if eval "$2" >/dev/null 2>&1; then echo "  PASS: $1"; PASS=$((PASS+1)); else echo "  FAIL: $1"; FAIL=$((FAIL+1)); fi; return 0; }

--- a/local-ci.sh
+++ b/local-ci.sh
@@ -13,7 +13,7 @@ CH_NS="socdemo-ch"
 KS_NS="socdemo"
 CHI="forensic-soc-db"
 INFER_JSON="$CH_DIR/infer_flat.json"
-KUBESCAPE_CHART_VER="${KUBESCAPE_CHART_VER:-1.41.0-duckling4}"
+KUBESCAPE_CHART_VER="${KUBESCAPE_CHART_VER:-1.41.0-duckling5}"
 
 PASS=0; FAIL=0
 check() { if eval "$2" >/dev/null 2>&1; then echo "  PASS: $1"; PASS=$((PASS+1)); else echo "  FAIL: $1"; FAIL=$((FAIL+1)); fi; return 0; }

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -103,7 +103,7 @@ manifests:
   helm:
     releases:
       - name: kubescape
-        remoteChart: https://github.com/k8sstormcenter/helm-charts/releases/download/kubescape-operator-1.41.0-duckling4/kubescape-operator-1.41.0-duckling4.tgz
+        remoteChart: https://github.com/k8sstormcenter/helm-charts/releases/download/kubescape-operator-1.41.0-duckling5/kubescape-operator-1.41.0-duckling5.tgz
         namespace: honey
         createNamespace: true
         valuesFiles:

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -103,7 +103,7 @@ manifests:
   helm:
     releases:
       - name: kubescape
-        remoteChart: https://github.com/k8sstormcenter/helm-charts/releases/download/kubescape-operator-1.41.0-duckling5/kubescape-operator-1.41.0-duckling5.tgz
+        remoteChart: https://github.com/k8sstormcenter/helm-charts/releases/download/kubescape-operator-1.41.0-duckling6/kubescape-operator-1.41.0-duckling6.tgz
         namespace: honey
         createNamespace: true
         valuesFiles:

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -103,7 +103,7 @@ manifests:
   helm:
     releases:
       - name: kubescape
-        remoteChart: https://github.com/k8sstormcenter/helm-charts/releases/download/kubescape-operator-1.41.0-duckling3/kubescape-operator-1.41.0-duckling3.tgz
+        remoteChart: https://github.com/k8sstormcenter/helm-charts/releases/download/kubescape-operator-1.41.0-duckling4/kubescape-operator-1.41.0-duckling4.tgz
         namespace: honey
         createNamespace: true
         valuesFiles:

--- a/tree/kubescape/values.yaml
+++ b/tree/kubescape/values.yaml
@@ -9,7 +9,7 @@ storage:
 nodeAgent:
   image:
     repository: docker.io/entlein/duckling
-    tag: v0.1.0-rogue7
+    tag: v0.1.0-rogue8
     pullPolicy: Always
   config:
     alertManagerExporterUrls:

--- a/tree/kubescape/values.yaml
+++ b/tree/kubescape/values.yaml
@@ -9,7 +9,7 @@ storage:
 nodeAgent:
   image:
     repository: docker.io/entlein/duckling
-    tag: v0.1.0-rogue6
+    tag: v0.1.0-rogue7
     pullPolicy: Always
   config:
     alertManagerExporterUrls:


### PR DESCRIPTION
Pins kubescape-operator chart 1.41.0-duckling5 (appVersion v0.1.0-rogue8) in skaffold.yaml, Makefile, local-ci.sh and the install notes; node-agent image tag v0.1.0-rogue8 in tree/kubescape/values.yaml. Storage stays rc-rogue5.

Validated on a k3s rig: label lifecycle legs in alert and enforce mode, restart, idle, and the managed-by casing case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014GDT6HWiFmRxmUaGFSKjPY