### PR TITLE
make kubescape: apply tree/kubescape/rule-alert-binding.yaml

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -66,6 +66,7 @@ kubescape:
 	kubectl create secret docker-registry duckling-pull -n honey --from-file=.dockerconfigjson=$(HOME)/.docker/config.json --dry-run=client -o yaml | kubectl apply -f -
 	helm upgrade --install kubescape kubescape/kubescape-operator --version $(KUBESCAPE_CHART_VER) -n honey --create-namespace --values tree/kubescape/values.yaml
 	-kubectl apply  -f tree/kubescape/default-rules.yaml
+	-kubectl apply  -f tree/kubescape/rule-alert-binding.yaml
 	sleep 5
 	-kubectl rollout restart -n honey ds node-agent
 	-kubectl wait --for=condition=ready pod -l app=kubevuln  -n honey --timeout 120s

--- a/local-ci.sh
+++ b/local-ci.sh
@@ -107,6 +107,7 @@ if ! helm status kubescape -n "$KS_NS" &>/dev/null; then
   helm upgrade --install kubescape kubescape/kubescape-operator --version "$KUBESCAPE_CHART_VER" -n "$KS_NS" --create-namespace --values "$KS_DIR/values.yaml" --set ksNamespace="$KS_NS" --set clusterName=socdemo --set "excludeNamespaces=kube-system\,kube-public\,kube-node-lease\,$CH_NS\,$KS_NS" --wait --timeout 180s 2>/dev/null || echo "  kubescape install may need retry"
 fi
 kubectl apply -f "$KS_DIR/default-rules.yaml" -n "$KS_NS" 2>/dev/null || true
+kubectl apply -f "$KS_DIR/rule-alert-binding.yaml" -n "$KS_NS" 2>/dev/null || true
 
 # Vector — rewrite the ClickHouse endpoint to point at socdemo-ch namespace
 PATCHED_VALUES=$(mktemp)


### PR DESCRIPTION
The Makefile target and local-ci.sh applied default-rules.yaml but not rule-alert-binding.yaml, so a stack installed with make kubescape had no RuntimeRuleAlertBinding and produced no rule detections. skaffold already applies both.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014GDT6HWiFmRxmUaGFSKjPY