### PR TITLE
kubescape default rules: port-aware was_selector_in_egress/ingress overload

### DIFF
--- a/tree/kubescape/default-rules.yaml
+++ b/tree/kubescape/default-rules.yaml
@@ -312,7 +312,7 @@ spec:
               && !event.dstAddr.startsWith('127.')
               && event.dstAddr != '::1'
               && !cp.was_address_port_protocol_in_egress(event.containerId, event.dstAddr, event.dstPort, event.proto)
-              && !cp.was_selector_in_egress(event.containerId, event.dstNamespace, event.dstPodLabels)
+              && !cp.was_selector_in_egress(event.containerId, event.dstNamespace, event.dstPodLabels, event.dstPort, event.proto)
         uniqueId: event.dstAddr + '_' + string(event.dstPort) + '_' + event.proto
       id: R0011
       isTriggerAlert: true
@@ -343,7 +343,7 @@ spec:
               && !event.dstAddr.startsWith('127.')
               && event.dstAddr != '::1'
               && !cp.was_address_port_protocol_in_ingress(event.containerId, event.dstAddr, event.dstPort, event.proto)
-              && !cp.was_selector_in_ingress(event.containerId, event.dstNamespace, event.dstPodLabels)
+              && !cp.was_selector_in_ingress(event.containerId, event.dstNamespace, event.dstPodLabels, event.dstPort, event.proto)
         uniqueId: event.dstAddr + '_' + string(event.dstPort) + '_' + event.proto
       id: R0012
       isTriggerAlert: true


### PR DESCRIPTION
R0011 and R0012 called the 3-argument cp.was_selector_in_egress/ingress; the node-agent CEL library registers only the port-aware 5-argument overload, so both rules failed to compile and never fired. Same change as k8sstormcenter/bob PR #219.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014GDT6HWiFmRxmUaGFSKjPY