### PR TITLE
kubescape values: cooldown is off and stays off

### DIFF
--- a/tree/kubescape/values.yaml
+++ b/tree/kubescape/values.yaml
@@ -18,20 +18,22 @@ nodeAgent:
     learningPeriod: 10m
     updatePeriod: 10000m
     networkServiceResolution: true
-    # Cooldown is OFF on purpose: every rule hit is emitted so a measurement run
-    # counts what the sensor actually produces rather than what it reports after
-    # suppression. Code defaults are 1h / count 1 (node-agent pkg/config).
+    # Cooldown is OFF on purpose: every rule hit is emitted so a measurement
+    # run counts what the sensor actually produces rather than what it reports
+    # after suppression. Code defaults are 1h / count 1 (node-agent
+    # pkg/config).
     #
-    # It is also the volume multiplier behind every downstream memory finding. A
-    # cluster lost its control-plane node after a day of ~3200 alerts/hour: each
-    # alert is a synchronous exporter round-trip, a vector event, a CH row
-    # and a dx referral, and the export path leaks one connection per capture it
-    # triggers. Cooldown is what bounds a slow permanent stream; a burst ceiling
-    # does not, because such a stream sits below any ceiling that would not also
-    # suppress legitimate bursts. The real fix for a stream is to correct the
-    # classification that produces it, not to raise this.
+    # It is also the volume multiplier behind every downstream memory finding.
+    # A cluster lost its control-plane node after a day of ~3200 alerts/hour:
+    # each alert is a synchronous exporter round-trip, a vector event, a CH
+    # row and a dx referral, and the export path leaks one connection per
+    # capture it triggers. Cooldown is what bounds a slow permanent stream; a
+    # burst ceiling does not, because such a stream sits below any ceiling
+    # that would not also suppress legitimate bursts. The real fix for a
+    # stream is to correct the classification that produces it.
     #
-    # Turn it back on (1h / count 1) for any cluster that is not being measured.
+    # Turn it back on (1h / count 1) for any cluster that is not being
+    # measured.
     ruleCooldown:
       ruleCooldownDuration: 0h
       ruleCooldownAfterCount: 1000000000

--- a/tree/kubescape/values.yaml
+++ b/tree/kubescape/values.yaml
@@ -24,7 +24,7 @@ nodeAgent:
     #
     # It is also the volume multiplier behind every downstream memory finding. A
     # cluster lost its control-plane node after a day of ~3200 alerts/hour: each
-    # alert is a synchronous exporter round-trip, a vector event, a ClickHouse row
+    # alert is a synchronous exporter round-trip, a vector event, a CH row
     # and a dx referral, and the export path leaks one connection per capture it
     # triggers. Cooldown is what bounds a slow permanent stream; a burst ceiling
     # does not, because such a stream sits below any ceiling that would not also

--- a/tree/kubescape/values.yaml
+++ b/tree/kubescape/values.yaml
@@ -18,6 +18,20 @@ nodeAgent:
     learningPeriod: 10m
     updatePeriod: 10000m
     networkServiceResolution: true
+    # Cooldown is OFF on purpose: every rule hit is emitted so a measurement run
+    # counts what the sensor actually produces rather than what it reports after
+    # suppression. Code defaults are 1h / count 1 (node-agent pkg/config).
+    #
+    # It is also the volume multiplier behind every downstream memory finding. A
+    # cluster lost its control-plane node after a day of ~3200 alerts/hour: each
+    # alert is a synchronous exporter round-trip, a vector event, a ClickHouse row
+    # and a dx referral, and the export path leaks one connection per capture it
+    # triggers. Cooldown is what bounds a slow permanent stream; a burst ceiling
+    # does not, because such a stream sits below any ceiling that would not also
+    # suppress legitimate bursts. The real fix for a stream is to correct the
+    # classification that produces it, not to raise this.
+    #
+    # Turn it back on (1h / count 1) for any cluster that is not being measured.
     ruleCooldown:
       ruleCooldownDuration: 0h
       ruleCooldownAfterCount: 1000000000

--- a/tree/kubescape/values.yaml
+++ b/tree/kubescape/values.yaml
@@ -18,22 +18,19 @@ nodeAgent:
     learningPeriod: 10m
     updatePeriod: 10000m
     networkServiceResolution: true
-    # Cooldown is OFF on purpose: every rule hit is emitted so a measurement
-    # run counts what the sensor actually produces rather than what it reports
-    # after suppression. Code defaults are 1h / count 1 (node-agent
-    # pkg/config).
+    # Cooldown is OFF and stays off. Suppression hides false positives instead
+    # of removing them; we deal with them by authoring good profiles and by
+    # fixing the auto-learning, and every rule hit has to be emitted for the
+    # detection-quality measurement to count what the sensor actually
+    # produces. Code defaults are 1h / count 1 (node-agent pkg/config); do not
+    # restore them here.
     #
-    # It is also the volume multiplier behind every downstream memory finding.
-    # A cluster lost its control-plane node after a day of ~3200 alerts/hour:
-    # each alert is a synchronous exporter round-trip, a vector event, a CH
-    # row and a dx referral, and the export path leaks one connection per
-    # capture it triggers. Cooldown is what bounds a slow permanent stream; a
-    # burst ceiling does not, because such a stream sits below any ceiling
-    # that would not also suppress legitimate bursts. The real fix for a
-    # stream is to correct the classification that produces it.
-    #
-    # Turn it back on (1h / count 1) for any cluster that is not being
-    # measured.
+    # Consequence to design for rather than suppress: each alert is a
+    # synchronous exporter round-trip, a vector event, a CH row and a dx
+    # referral, and the export path leaks one connection per capture it
+    # triggers. A cluster lost its control-plane node after a day at ~3200
+    # alerts/hour. The fix for that rate is correct classification and
+    # complete profiles, not a ceiling.
     ruleCooldown:
       ruleCooldownDuration: 0h
       ruleCooldownAfterCount: 1000000000


### PR DESCRIPTION
The cooldown block disables suppression entirely. That is deliberate and permanent: suppression hides false positives instead of removing them. We deal with them by authoring good profiles and by fixing the auto-learning, and every rule hit has to be emitted for the detection-quality measurement to count what the sensor actually produces.

The note also records the consequence to design for rather than suppress: each alert costs a synchronous exporter round-trip, a vector event, a ClickHouse row and a dx referral, and the export path leaks one connection per capture it triggers.

Comment only, no value changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014GDT6HWiFmRxmUaGFSKjPY