### PR TITLE
kubescape: move to chart duckling12 with matching node-agent and storage pins

### DIFF
--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -103,7 +103,7 @@ manifests:
   helm:
     releases:
       - name: kubescape
-        remoteChart: https://github.com/k8sstormcenter/helm-charts/releases/download/kubescape-operator-1.41.0-duckling6/kubescape-operator-1.41.0-duckling6.tgz
+        remoteChart: https://github.com/k8sstormcenter/helm-charts/releases/download/kubescape-operator-1.41.0-duckling12/kubescape-operator-1.41.0-duckling12.tgz
         namespace: honey
         createNamespace: true
         valuesFiles:

--- a/tree/kubescape/values.yaml
+++ b/tree/kubescape/values.yaml
@@ -5,11 +5,11 @@ imagePullSecrets: duckling-pull
 storage:
   image:
     repository: ghcr.io/k8sstormcenter/storage
-    tag: rc-rogue5
+    tag: rc-rogue19
 nodeAgent:
   image:
     repository: docker.io/entlein/duckling
-    tag: v0.1.0-rogue8
+    tag: v0.1.0-rogue19
     pullPolicy: Always
   config:
     alertManagerExporterUrls:


### PR DESCRIPTION
The skaffold chart reference was six releases behind at `duckling6`, and `tree/kubescape/values.yaml` pinned node-agent and storage independently of it.

| | before | after |
|---|---|---|
| chart | `1.41.0-duckling6` | `1.41.0-duckling12` |
| node-agent | `v0.1.0-rogue8` | `v0.1.0-rogue19` |
| storage | `rc-rogue5` | `rc-rogue19` |

## Why all three move together

An explicitly pinned image tag in values **overrides whatever the chart ships**. Bumping the chart alone leaves the pinned component exactly where it was, while the chart pin, chart version and appVersion all read as current.

That has caught two clusters this week: one where storage stayed on the old image through a chart bump that reported a clean deploy, and one where a `helm upgrade` silently carried the previous release's values forward. Both are the same shape — a successful operation that preserves the old state — which is why this changes the chart reference and both pins in one commit rather than separately.

Verify after deploying by reading the **workloads**, not the chart:

```
kubectl -n honey get ds node-agent -o jsonpath='{.spec.template.spec.containers[0].image}'
kubectl -n honey get deploy storage -o jsonpath='{.spec.template.spec.containers[0].image}'
```

## Chart provenance

The tarball was verified before pinning: **77466 bytes**, `sha256 a186f1debc62f27f8cfbe549aeb168e6d37d9bf00a69bd849bbac226ae8ea1ff`, carrying `appVersion v0.1.0-rogue19` and `storage rc-rogue19` — so the chart's own defaults now agree with the pins above instead of fighting them.

Note that GitHub Pages is disabled on the chart repository, so `helm repo add` does not work and the release tarball URL is the only install route. That is why the reference is a direct URL.

## What the versions bring

- **A fully learned profile stays fully learned across a node-agent restart.** Previously a restart could re-stamp completed profiles partial.
- **Partial profiles govern again.** A partial profile is enforced rather than skipped, so a workload already running when the agent started is watched rather than silently unmonitored.
- **The entrypoint exec is captured.** Losing it was deterministic on the previously pinned node-agent; for a container that execs only at startup it produced a completely empty profile — which appears to explain a population of empty profiles observed on infrastructure namespaces.
- **Storage** carries four upstream fixes cherry-picked with provenance, and deliberately does **not** carry upstream's single-writer redesign, which is still taking deadlock and stall fixes.

## One behavioural change to expect

This deployment does not set `nodeAgent.config.prometheusExporter`, so the chart default applies — and in `duckling12` that default is `enable`. The metrics endpoint on `:8080` will start serving after this lands, where previously it answered empty because the flag built the counters without starting the listener.

If that is not wanted here, add an explicit `nodeAgent.config.prometheusExporter: disable` to the values in this PR and it will stay off.

No configuration other than the three versions is changed.