### PR TITLE
kubescape: move to chart duckling13, storage back to rc-rogue5

### DIFF
--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -103,7 +103,7 @@ manifests:
   helm:
     releases:
       - name: kubescape
-        remoteChart: https://github.com/k8sstormcenter/helm-charts/releases/download/kubescape-operator-1.41.0-duckling12/kubescape-operator-1.41.0-duckling12.tgz
+        remoteChart: https://github.com/k8sstormcenter/helm-charts/releases/download/kubescape-operator-1.41.0-duckling13/kubescape-operator-1.41.0-duckling13.tgz
         namespace: honey
         createNamespace: true
         valuesFiles:

--- a/tree/kubescape/values.yaml
+++ b/tree/kubescape/values.yaml
@@ -5,7 +5,7 @@ imagePullSecrets: duckling-pull
 storage:
   image:
     repository: ghcr.io/k8sstormcenter/storage
-    tag: rc-rogue19
+    tag: rc-rogue5
 nodeAgent:
   image:
     repository: docker.io/entlein/duckling


### PR DESCRIPTION
Reverts the storage half of #271. **node-agent is unchanged** at `v0.1.0-rogue19`; only storage moves back.

| | before | after |
|---|---|---|
| chart | `1.41.0-duckling12` | `1.41.0-duckling13` |
| node-agent | `v0.1.0-rogue19` | `v0.1.0-rogue19` (unchanged) |
| storage | `rc-rogue19` | `rc-rogue5` |

## Why

Three component-test subtests began failing on the previous chart, all in the authored and signed profile path:

- an authored profile binding to a workload
- a signed suggestion healing in place
- a signed overlay being enforced rather than merely accepted

Each failed at a **poll cap** rather than on a wrong answer — the shape of waiting for something that never arrives, not of computing something incorrect.

The same three passed on the **same node-agent image** with `rc-rogue5`, and the storage bump was the only deliberate change between the two runs. A control-plane starvation on the test rig was ruled out as the cause for these specific failures: an independent witness on a different host (kubelet node-lease renewals, emitted every 10s) shows a perfect record across the entire window in which they failed, with degradation beginning roughly 85 minutes later.

**The suspicion is not proven.** A two-arm isolation on a clean cluster — same cluster, storage rolled between the two versions, everything else held — is still running. This reverts rather than waits because this deployment is the fleet standard, and a suspected regression in the profile binding path should not be what every cluster installs while the question is open.

## Why both files move together

Same reason as #271: the pinned tag in `tree/kubescape/values.yaml` overrides whatever the chart ships. Changing the chart reference alone would leave storage on `rc-rogue19` while the chart pin, chart version and appVersion all read as reverted.

Verify after deploying by reading the **workloads**:

```
kubectl -n honey get deploy storage -o jsonpath='{.spec.template.spec.containers[0].image}'
kubectl -n honey get ds node-agent -o jsonpath='{.spec.template.spec.containers[0].image}'
```

## Chart provenance

Verified from the published tarball: **77463 bytes**, `sha256 41fb3771b1b4d62fc084fd73bc48bd133df5e1b89ff8a7804eceed13e663257d`, carrying `appVersion v0.1.0-rogue19` and `storage rc-rogue5`.

## What is not lost

The four upstream storage fixes are reverted on the storage branch as well, so `rc-rogue5` and that branch agree again. They were individually verified before release and can return unchanged once the binding question is settled — this is a hold, not a rejection.

Everything node-agent side in the previous bump is retained: restart-survival of completed profiles, partial profiles governing, and the entrypoint-capture fix.