### PR TITLE
kubescape: pin node-agent rogue23 and storage rc-rogue22

### DIFF
--- a/tree/kubescape/values.yaml
+++ b/tree/kubescape/values.yaml
@@ -5,11 +5,11 @@ imagePullSecrets: duckling-pull
 storage:
   image:
     repository: ghcr.io/k8sstormcenter/storage
-    tag: rc-rogue21
+    tag: rc-rogue22
 nodeAgent:
   image:
     repository: docker.io/entlein/duckling
-    tag: v0.1.0-rogue20
+    tag: v0.1.0-rogue23
     pullPolicy: Always
   config:
     alertManagerExporterUrls:

--- a/tree/kubescape/values.yaml
+++ b/tree/kubescape/values.yaml
@@ -5,11 +5,11 @@ imagePullSecrets: duckling-pull
 storage:
   image:
     repository: ghcr.io/k8sstormcenter/storage
-    tag: rc-rogue5
+    tag: rc-rogue21
 nodeAgent:
   image:
     repository: docker.io/entlein/duckling
-    tag: v0.1.0-rogue19
+    tag: v0.1.0-rogue20
     pullPolicy: Always
   config:
     alertManagerExporterUrls:


### PR DESCRIPTION
Moves the kubescape image pins to the builds now running on the demo cluster. The chart itself is unchanged.

| component | from | to |
|---|---|---|
| node-agent | `v0.1.0-rogue19` | `v0.1.0-rogue23` |
| storage | `rc-rogue5` | `rc-rogue22` |

**node-agent rogue23** closes two defects.

The profile-write queue's failure classifier had no `AlreadyExists` case, so a duplicate delivery retried until it starved the queue and pushed out every newer profile — a total, silent profile-write outage.

Under queue pressure the agent evicted a container's *final* chunk and replaced it with a "stitch" that copied the chunk's `completion: complete` annotation onto an empty body — so a container that lost its recorded behaviour landed as a completed, empty allowlist, indistinguishable from one that did nothing. Eviction is now a policy: a fresh non-final chunk at capacity is refused and the container keeps its events; a final chunk is admitted over the bound; nothing final is ever evicted; a stitch declares `partial`. Events arriving before the container is registered are held rather than dropped. With the queue bound forced low, an 80-pod burst on the lab cluster now yields 80 complete profiles where every previous build lost some.

**storage rc-rogue22** collapses every digits-only segment under `/proc` (pid, tid, fd, irq — none carries meaning past its run) and any zero-padded counter anywhere (nginx `proxy_temp`'s `0000000001`), while leaving meaningful integers alone. Named procfs reads that were being absorbed into the pid pattern are preserved.

**Verification** — component tests green on this pair: profile-write lane (`Test_08/15/16/17/19/22/58`, 7/7) and opens/path-collapse lane (`Test_27/33/43`, 21/21). Node-agent and storage unit suites pass, with new tests that fail on the pre-fix code and pass after, including an in-process test of the full write path under queue pressure.