### PR TITLE
kubescape: chart duckling14 and node-agent rogue26

### DIFF
--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -103,7 +103,7 @@ manifests:
   helm:
     releases:
       - name: kubescape
-        remoteChart: https://github.com/k8sstormcenter/helm-charts/releases/download/kubescape-operator-1.41.0-duckling13/kubescape-operator-1.41.0-duckling13.tgz
+        remoteChart: https://github.com/k8sstormcenter/helm-charts/releases/download/kubescape-operator-1.41.0-duckling14/kubescape-operator-1.41.0-duckling14.tgz
         namespace: honey
         createNamespace: true
         valuesFiles:

--- a/tree/kubescape/values.yaml
+++ b/tree/kubescape/values.yaml
@@ -9,7 +9,7 @@ storage:
 nodeAgent:
   image:
     repository: docker.io/entlein/duckling
-    tag: v0.1.0-rogue23
+    tag: v0.1.0-rogue26
     pullPolicy: Always
   config:
     alertManagerExporterUrls:


### PR DESCRIPTION
Brings soc up to what the clusters run, in both places it is declared.

| | from | to |
|---|---|---|
| chart (`skaffold.yaml`) | `kubescape-operator-1.41.0-duckling13` | `kubescape-operator-1.41.0-duckling14` |
| node-agent (`values.yaml`) | `v0.1.0-rogue23` | `v0.1.0-rogue26` |
| storage (`values.yaml`) | `rc-rogue22` | unchanged |

**Why the chart bump matters on its own.** duckling13 declared node-agent `rogue19` and storage `rc-rogue5` as its defaults. Anyone deploying the published chart — the documented path — got images four and seventeen builds behind the clusters, and only the values override in this repo corrected it. duckling14 carries `rogue26` and `rc-rogue22` itself, so the chart is no longer a downgrade waiting to happen.

The values pins are kept and now **agree with** the chart rather than correcting it. They stay because the node-agent image is private, so the pull policy and pull secret belong with the values, and because an explicit pin makes a wrong deploy visible in review instead of silent.

**What rogue26 closes** — three defects, two of them introduced by the previous build and found while auditing it:

- **Unbounded memory.** A container holding unsent events while the queue refused them had no bound, so a storage outage (up to the full 30-minute retry budget) accumulated on every container of the node. Measured 1000 then 2000 events held, linear. Now capped at twice one profile's worth, peak measured at 1.97x, with dropped events declared so the profile reads `partial`.
- **Unbounded disk.** The allowance that stops a container's last write being evicted had no ceiling, and that queue lives on an `emptyDir` with no `sizeLimit` — the node's ephemeral storage. A node that fills it gets pods evicted by the kubelet, including pods unrelated to this stack. Measured 200 items in a queue bounded at 4; 8 after.
- **Data race** on the field that decides whether a profile is stamped `completed`, written from several goroutines with no synchronisation. Caught two runs in eight; ten clean after. Predates this week's work.

Plus: a container that nothing is evaluating is now named in the log. On the demo cluster that surfaced 15 such containers on the first grep — a population that was previously invisible.

**Verification:** component tests on this pair, three lanes, 34 tests — profile write path 7/7, opens and path collapse 21/21, lifecycle 6/6. Unit suites pass, race detector clean over ten runs. Both images verified present in their registries and running on the demo cluster.

**Not claimed:** a false-positive rate comparison across the roll. Pods are replaced by a roll and there is no persistent alert sink today, so before/after is unmeasurable. What is established is no new FP class and no rule flooding.