### PR TITLE
kubescape: drop the Alertmanager exporter URL nothing deploys

### DIFF
--- a/tree/kubescape/values.yaml
+++ b/tree/kubescape/values.yaml
@@ -12,8 +12,10 @@ nodeAgent:
     tag: v0.1.0-rogue26
     pullPolicy: Always
   config:
-    alertManagerExporterUrls:
-      - alertmanager.honey.svc.cluster.local:9093
+    # Nothing in soc-stack deploys Alertmanager. With a URL set, every rule hit
+    # is also a failed POST (DNS: no such host) logged at warn — one per alert.
+    # The path that feeds ClickHouse is stdoutExporter -> vector, chart default.
+    alertManagerExporterUrls: []
     maxLearningPeriod: 24h
     learningPeriod: 10m
     updatePeriod: 10000m


### PR DESCRIPTION
## Observed

On a fresh `skaffold deploy -m soc-stack` (node-agent `v0.1.0-rogue26`), every rule hit is followed by:

```
AlertManagerExporter.SendRuleAlert - error sending alert
Post "http://alertmanager.honey.svc.cluster.local:9093/api/v2/alerts":
  dial tcp: lookup alertmanager.honey.svc.cluster.local on 10.43.0.10:53: no such host
```

One failed POST at warn level per alert, for the life of the deployment.

## Cause

`tree/kubescape/values.yaml` set `nodeAgent.config.alertManagerExporterUrls` to `alertmanager.honey.svc.cluster.local:9093`, but nothing in soc-stack deploys Alertmanager — `skaffold.yaml` has no such module and `tree/` carries no manifest for it. The reference was carried over from a CI lane that does install one.

## Fix

Restore the chart default `alertManagerExporterUrls: []`. The path that feeds the SOC views is `stdoutExporter -> vector -> ClickHouse`, which is untouched: the alert above was itself read from node-agent stdout, and the ClickHouse rows arrive through vector regardless of the Alertmanager exporter's fate.

## Verified

- Chart default confirmed in `kubescape-operator` `values.yaml` (`alertManagerExporterUrls: []`, `stdoutExporter: true`).
- The same alert that produced the DNS warning was present in `forensic_db` — confirming stdout → vector is the live path and no detection depends on Alertmanager here.

Not changed: `maxLearningPeriod` / `learningPeriod` / `updatePeriod`. Those interact with a node-agent governance question tracked separately and are left as-is on purpose.