### PR TITLE
kubescape: pin node-agent rogue28

### DIFF
--- a/tree/kubescape/values.yaml
+++ b/tree/kubescape/values.yaml
@@ -9,7 +9,7 @@ storage:
 nodeAgent:
   image:
     repository: docker.io/entlein/duckling
-    tag: v0.1.0-rogue26
+    tag: v0.1.0-rogue28
     pullPolicy: Always
   config:
     # Nothing in soc-stack deploys Alertmanager. With a URL set, every rule hit


### PR DESCRIPTION
Pins `docker.io/entlein/duckling:v0.1.0-rogue28` (`entlein/node-agent` `feat/rogue-artifacts` @ `b1c1d103`).

What changes on the cluster, per entlein/node-agent#1 v5:
- A pod carrying `kubescape.io/user-defined-profile` whose profile does not resolve runs **deny-all from t=0** and fires R1017 `unbound` after a short grace — in every mode. Previously it was silent for `maxLearningPeriod` and then governed by its own shadow.
- The shadow profile learns for the life of the container and is never used to judge a labelled pod. `status: ready` is the window-end stamp; nothing is stamped `completed` by learning any more (`completed` = the container terminated).
- Applying the named SBoB heals within a tick; deleting it holds the last projection ~20s, then deny-all.
- Entry rebuilds keep the workload identity (previously all rebuilt entries in a namespace shared one RogueArtifact per container name).
- `kubescape.io/learning` is ignored, with one warning.

Unchanged here: `maxLearningPeriod: 24h` — under v5 it only delays when an **unlabelled** pod starts being judged against its shadow (row 1); labelled pods are unaffected.

Verified: unit truth table on the dungeon fixture; rig acceptance (deny-all at t=0, R1017 at +7s, probe alerts with no window, shadow `ready`, heal/unbind round trip).