### PR TITLE
clickhouse-lab: bound the analyst user's memory as a whole (T4)

### DIFF
--- a/tree/clickhouse-lab/installation.yaml
+++ b/tree/clickhouse-lab/installation.yaml
@@ -42,7 +42,15 @@ spec:
       forensic_analyst/max_execution_time: "90"
       forensic_analyst/max_threads: "2"
       forensic_analyst/max_concurrent_queries_for_user: "24"
-      forensic_analyst/max_memory_usage: "4000000000"
+      # Memory: the container limit is 6Gi and the server keeps ~90% of it.
+      # 24 concurrent analyst queries at 4 GB each is 96 GB of allowed
+      # allocation on a 5.4 GB server — one browser tab of auto-refreshing
+      # profile panels OOMKilled the container on 2026-09-10. A query that
+      # exceeds its cap fails with MEMORY_LIMIT_EXCEEDED; the server, every
+      # insert and every other query continue. The largest known view read
+      # (dx_profiles__latest over every generation) is 82 MiB.
+      forensic_analyst/max_memory_usage: "1500000000"
+      forensic_analyst/max_memory_usage_for_user: "2500000000"
 
       # Ingest: INSERT allowed, no DELETE/ALTER/DDL.
       # Async insert: CH accumulates rows in RAM and flushes in bulk,


### PR DESCRIPTION
Truth table T4 (entlein/dx#157 rows 21–22): a panel query that would exceed the per-query cap fails with MEMORY_LIMIT_EXCEEDED; the server, every insert and every other query continue; the AE/ingest users are unaffected.

Today: `max_memory_usage` 4 GB per query × `max_concurrent_queries_for_user` 24 on a 6Gi container (server ~5.4 GB) — one browser tab of auto-refreshing profile panels OOMKilled the container on 2026-09-10 (exit 137, 09:39:19Z). This sets per query 1.5 GB and adds a per-user total of 2.5 GB. The largest known view read is 82 MiB (dx_profiles__latest pinned over every generation), so no panel is affected.

Applies on the next ClickHouse (re)install or a CHI reconcile; no data change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014GDT6HWiFmRxmUaGFSKjPY